### PR TITLE
Add remote URL input support for convert subcommand

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { defineCommand, runMain } from "citty";
 import pc from "picocolors";
 import path from "path";
 import { convert, type Format, type Fit } from "./processor";
+import { isUrl, deriveFilenameFromUrl, downloadImage } from "./url";
 
 const SUPPORTED_FORMATS = ["png", "jpeg", "jpg", "webp"];
 
@@ -58,7 +59,7 @@ const convertCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const inputPath = path.resolve(args.input);
+    const remoteInput = isUrl(args.input);
     const toFormat = args.to.toLowerCase();
 
     // Validate output format
@@ -67,18 +68,38 @@ const convertCommand = defineCommand({
       process.exit(1);
     }
 
-    // Validate input file exists
-    const inputFile = Bun.file(inputPath);
-    if (!(await inputFile.exists())) {
-      console.error(pc.red(`Error: File not found: ${inputPath}`));
-      process.exit(1);
-    }
+    let inputBuffer: Buffer;
+    let inputBasename: string;
 
-    // Validate input format
-    const inputExt = path.extname(inputPath).slice(1).toLowerCase();
-    if (!SUPPORTED_FORMATS.includes(inputExt)) {
-      console.error(pc.red(`Error: Unsupported input format "${inputExt}". Supported: png, jpeg, jpg, webp`));
-      process.exit(1);
+    if (remoteInput) {
+      // Remote URL input
+      try {
+        inputBuffer = await downloadImage(args.input);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        await Bun.write(Bun.stderr, pc.red(`Error: ${message}\n`));
+        process.exit(1);
+      }
+      const format = normalizeFormat(toFormat);
+      inputBasename = deriveFilenameFromUrl(args.input, format === "jpeg" ? "jpg" : format);
+    } else {
+      // Local file input
+      const inputPath = path.resolve(args.input);
+
+      const inputFile = Bun.file(inputPath);
+      if (!(await inputFile.exists())) {
+        console.error(pc.red(`Error: File not found: ${inputPath}`));
+        process.exit(1);
+      }
+
+      const inputExt = path.extname(inputPath).slice(1).toLowerCase();
+      if (!SUPPORTED_FORMATS.includes(inputExt)) {
+        console.error(pc.red(`Error: Unsupported input format "${inputExt}". Supported: png, jpeg, jpg, webp`));
+        process.exit(1);
+      }
+
+      inputBuffer = Buffer.from(await inputFile.arrayBuffer());
+      inputBasename = path.basename(inputPath, path.extname(inputPath));
     }
 
     // Parse quality
@@ -122,21 +143,25 @@ const convertCommand = defineCommand({
     }
 
     try {
-      const inputBuffer = Buffer.from(await inputFile.arrayBuffer());
       const format = normalizeFormat(toFormat);
 
       const result = await convert(inputBuffer, { format, quality, width, height, fit });
 
-      // Output path: use --output if provided, otherwise same directory with new extension
+      // Output path: use --output if provided, otherwise CWD with derived filename
       let outputPath: string;
       if (args.output) {
         outputPath = path.resolve(args.output);
       } else {
         const outExt = format === "jpeg" ? "jpg" : format;
-        outputPath = path.join(
-          path.dirname(inputPath),
-          `${path.basename(inputPath, path.extname(inputPath))}.${outExt}`
-        );
+        if (remoteInput) {
+          outputPath = path.resolve(`${inputBasename}`);
+        } else {
+          const inputPath = path.resolve(args.input);
+          outputPath = path.join(
+            path.dirname(inputPath),
+            `${inputBasename}.${outExt}`
+          );
+        }
       }
 
       // Check if output file already exists

--- a/src/url.ts
+++ b/src/url.ts
@@ -1,0 +1,39 @@
+const MAX_DOWNLOAD_SIZE = 50 * 1024 * 1024; // 50MB
+
+export function isUrl(input: string): boolean {
+  return input.startsWith("https://") || input.startsWith("http://");
+}
+
+export function deriveFilenameFromUrl(url: string, format: string): string {
+  const pathname = new URL(url).pathname;
+  const basename = pathname.split("/").pop() || "image";
+  const nameWithoutExt = basename.replace(/\.[^.]+$/, "");
+  const ext = format === "jpeg" ? "jpg" : format;
+  return `${nameWithoutExt}.${ext}`;
+}
+
+export async function downloadImage(url: string): Promise<Buffer> {
+  let response: Response;
+  try {
+    response = await fetch(url);
+  } catch {
+    throw new Error(`Failed to download image from ${url}`);
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to download image from ${url} (HTTP ${response.status})`);
+  }
+
+  const contentLength = response.headers.get("content-length");
+  if (contentLength && parseInt(contentLength, 10) > MAX_DOWNLOAD_SIZE) {
+    throw new Error(`Download exceeds 50MB size limit`);
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+
+  if (buffer.length > MAX_DOWNLOAD_SIZE) {
+    throw new Error(`Download exceeds 50MB size limit`);
+  }
+
+  return buffer;
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,6 +1,7 @@
 import { test, expect, describe, afterEach } from "bun:test";
 import fs from "fs/promises";
 import path from "path";
+import net from "net";
 
 const CLI = path.resolve("src/index.ts");
 const FIXTURES = path.resolve("test/fixtures");
@@ -34,7 +35,37 @@ async function run(...args: string[]) {
   return { exitCode, stdout, stderr };
 }
 
-afterEach(cleanTmp);
+let server: ReturnType<typeof Bun.serve> | null = null;
+
+function startFixtureServer() {
+  server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+
+      if (url.pathname === "/404") {
+        return new Response("Not found", { status: 404 });
+      }
+
+      const fixtureName = url.pathname.slice(1); // strip leading /
+      const fixturePath = path.join(FIXTURES, fixtureName);
+      const file = Bun.file(fixturePath);
+      if (await file.exists()) {
+        return new Response(file);
+      }
+      return new Response("Not found", { status: 404 });
+    },
+  });
+  return server;
+}
+
+afterEach(async () => {
+  await cleanTmp();
+  if (server) {
+    server.stop();
+    server = null;
+  }
+});
 
 describe("CLI convert", () => {
   test("converts PNG to WebP and creates output file", async () => {
@@ -191,7 +222,7 @@ describe("CLI convert", () => {
     expect(stderr).toContain("Unsupported fit mode");
   });
 
-  test("errors on unsupported input format", async () => {
+  test("errors on unsupported input format (local)", async () => {
     await ensureTmp();
     const gifPath = path.join(TMP, "fake.gif");
     await Bun.write(gifPath, "fake gif data");
@@ -200,5 +231,65 @@ describe("CLI convert", () => {
 
     expect(exitCode).toBe(1);
     expect(stderr).toContain("Unsupported input format");
+  });
+});
+
+describe("CLI convert (remote URL)", () => {
+  test("converts a remote image URL to target format", async () => {
+    await ensureTmp();
+    const srv = startFixtureServer();
+    const url = `http://localhost:${srv.port}/sample.png`;
+
+    const { exitCode, stdout } = await run("convert", url, "--to", "webp");
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Saved to");
+    expect(stdout).toContain("sample.webp");
+
+    const outputPath = path.join(TMP, "sample.webp");
+    expect(await Bun.file(outputPath).exists()).toBe(true);
+  });
+
+  test("rejects downloads exceeding 50MB", async () => {
+    await ensureTmp();
+    // Use raw TCP server to send a Content-Length header that Bun won't override
+    const tcpServer = net.createServer((socket) => {
+      const size = 51 * 1024 * 1024;
+      socket.write(`HTTP/1.1 200 OK\r\nContent-Length: ${size}\r\nConnection: close\r\n\r\n`);
+      socket.end("x");
+    });
+    await new Promise<void>((resolve) => tcpServer.listen(0, resolve));
+    const tcpPort = (tcpServer.address() as net.AddressInfo).port;
+
+    const url = `http://localhost:${tcpPort}/oversized.jpg`;
+    const { exitCode, stderr } = await run("convert", url, "--to", "webp");
+
+    tcpServer.close();
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("50MB");
+  });
+
+  test("errors on network failure with clear message", async () => {
+    await ensureTmp();
+    const url = "http://localhost:19999/nonexistent.png";
+
+    const { exitCode, stderr } = await run("convert", url, "--to", "webp");
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Failed to download");
+  });
+
+  test("--output flag works with remote URLs", async () => {
+    await ensureTmp();
+    const srv = startFixtureServer();
+    const url = `http://localhost:${srv.port}/sample.png`;
+    const outputPath = path.join(TMP, "custom-remote.webp");
+
+    const { exitCode, stdout } = await run("convert", url, "--to", "webp", "--output", outputPath);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("custom-remote.webp");
+    expect(await Bun.file(outputPath).exists()).toBe(true);
   });
 });

--- a/test/url.test.ts
+++ b/test/url.test.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect } from "bun:test";
+import { isUrl, deriveFilenameFromUrl } from "../src/url";
+
+describe("isUrl", () => {
+  test("returns true for https URLs", () => {
+    expect(isUrl("https://example.com/photo.png")).toBe(true);
+  });
+
+  test("returns true for http URLs", () => {
+    expect(isUrl("http://example.com/photo.png")).toBe(true);
+  });
+
+  test("returns false for local file paths", () => {
+    expect(isUrl("./photo.png")).toBe(false);
+    expect(isUrl("/Users/me/photo.png")).toBe(false);
+    expect(isUrl("photo.png")).toBe(false);
+  });
+});
+
+describe("deriveFilenameFromUrl", () => {
+  test("extracts filename and replaces extension with target format", () => {
+    expect(deriveFilenameFromUrl("https://example.com/photo.png", "webp")).toBe("photo.webp");
+  });
+
+  test("handles URLs with path segments", () => {
+    expect(deriveFilenameFromUrl("https://s3-media0.fl.yelpcdn.com/bphoto/PHJIpAq5y8CoHr0lg-M0_g/o.jpg", "webp")).toBe("o.webp");
+  });
+
+  test("handles URLs with query strings", () => {
+    expect(deriveFilenameFromUrl("https://example.com/photo.png?width=100", "jpeg")).toBe("photo.jpg");
+  });
+
+  test("maps jpeg format to .jpg extension", () => {
+    expect(deriveFilenameFromUrl("https://example.com/photo.png", "jpeg")).toBe("photo.jpg");
+  });
+});


### PR DESCRIPTION
## Summary
- Add support for `http://` and `https://` URLs as input to `convert` subcommand
- Downloads remote images with a 50MB size cap and clear error on exceeded limit
- Derives output filename from URL path (e.g., `photo.webp` from `https://example.com/photo.png`)
- All existing flags (`--to`, `--quality`, `--width`, `--height`, `--fit`, `--output`, `--force`) work with remote URLs
- Network errors produce clear error messages with exit code 1

Closes #5

## Test plan
- [x] Unit tests for `isUrl()` — https, http, and local path detection
- [x] Unit tests for `deriveFilenameFromUrl()` — simple paths, deep paths, query strings, jpeg→jpg mapping
- [x] Integration test: remote URL converts to target format via local HTTP server
- [x] Integration test: 50MB download cap rejection via raw TCP server
- [x] Integration test: network failure produces clear error message
- [x] Integration test: `--output` flag works with remote URLs
- [x] All 45 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)