### PR TITLE
Extract output path resolution into dedicated module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env bun
 import { defineCommand, runMain } from "citty";
 import pc from "picocolors";
-import path from "path";
 import { convert, type Format, type Fit } from "./processor";
 import { loadImage } from "./loader";
+import { resolveOutputPath } from "./output-path";
 
 function normalizeFormat(fmt: string): Format {
   if (fmt === "jpg") return "jpeg";
@@ -119,18 +119,7 @@ const convertCommand = defineCommand({
       const format = normalizeFormat(toFormat);
       const result = await convert(image.buffer, { format, quality, width, height, fit });
 
-      // Output path: use --output if provided, otherwise derive from input
-      let outputPath: string;
-      if (args.output) {
-        outputPath = path.resolve(args.output);
-      } else {
-        const outExt = format === "jpeg" ? "jpg" : format;
-        if (image.kind === "remote") {
-          outputPath = path.resolve(`${image.basename}.${outExt}`);
-        } else {
-          outputPath = path.join(image.sourceDir, `${image.basename}.${outExt}`);
-        }
-      }
+      const outputPath = resolveOutputPath(image, format, { output: args.output });
 
       // Check if output file already exists
       if (!args.force && await Bun.file(outputPath).exists()) {

--- a/src/output-path.ts
+++ b/src/output-path.ts
@@ -1,0 +1,23 @@
+import path from "path";
+import type { LoadResult } from "./loader";
+import type { Format } from "./processor";
+
+export function resolveOutputPath(
+  image: LoadResult,
+  format: Format,
+  options?: { output?: string; cwd?: string }
+): string {
+  if (options?.output) {
+    const cwd = options.cwd ?? process.cwd();
+    return path.resolve(cwd, options.output);
+  }
+
+  const ext = format === "jpeg" ? "jpg" : format;
+
+  if (image.kind === "remote") {
+    const cwd = options?.cwd ?? process.cwd();
+    return path.join(cwd, `${image.basename}.${ext}`);
+  }
+
+  return path.join(image.sourceDir, `${image.basename}.${ext}`);
+}

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -24,7 +24,7 @@ describe("loadImage — remote (injected fetcher)", () => {
   });
 
   test("returns kind=remote with buffer and basename extracted from URL path", async () => {
-    const fakeFetch = async (_url: string) => makeResponse(TINY_IMAGE);
+    const fakeFetch = async () => makeResponse(TINY_IMAGE);
 
     const result = await loadImage("https://example.com/photos/sunset.png", fakeFetch);
 
@@ -35,7 +35,7 @@ describe("loadImage — remote (injected fetcher)", () => {
   });
 
   test("throws 'Failed to download' when fetcher throws a network error", async () => {
-    const fakeFetch = async (_url: string): Promise<Response> => {
+    const fakeFetch = async (): Promise<Response> => {
       throw new Error("network unavailable");
     };
 
@@ -45,7 +45,7 @@ describe("loadImage — remote (injected fetcher)", () => {
   });
 
   test("throws with HTTP status when fetcher returns a non-OK response", async () => {
-    const fakeFetch = async (_url: string) => makeResponse(TINY_IMAGE, 403);
+    const fakeFetch = async () => makeResponse(TINY_IMAGE, 403);
 
     await expect(loadImage("https://example.com/photo.png", fakeFetch)).rejects.toThrow(
       "HTTP 403"
@@ -54,7 +54,7 @@ describe("loadImage — remote (injected fetcher)", () => {
 
   test("throws size limit error when content-length header exceeds 50MB", async () => {
     const oversize = 51 * 1024 * 1024;
-    const fakeFetch = async (_url: string) =>
+    const fakeFetch = async () =>
       makeResponse(TINY_IMAGE, 200, { "content-length": String(oversize) });
 
     await expect(loadImage("https://example.com/big.jpg", fakeFetch)).rejects.toThrow("50MB");
@@ -62,7 +62,7 @@ describe("loadImage — remote (injected fetcher)", () => {
 
   test("throws size limit error when response body exceeds 50MB (no content-length)", async () => {
     const oversizeBody = new ArrayBuffer(51 * 1024 * 1024);
-    const fakeFetch = async (_url: string) => makeResponse(oversizeBody);
+    const fakeFetch = async () => makeResponse(oversizeBody);
 
     await expect(loadImage("https://example.com/big.jpg", fakeFetch)).rejects.toThrow("50MB");
   });

--- a/test/output-path.test.ts
+++ b/test/output-path.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect } from "bun:test";
+import { resolveOutputPath } from "../src/output-path";
+import type { LoadResult } from "../src/loader";
+
+const localImage: LoadResult = {
+  kind: "local",
+  buffer: Buffer.alloc(0),
+  basename: "photo",
+  sourceDir: "/home/user/images",
+};
+
+const remoteImage: LoadResult = {
+  kind: "remote",
+  buffer: Buffer.alloc(0),
+  basename: "photo",
+};
+
+describe("resolveOutputPath", () => {
+  test("local image saves next to source file with new extension", () => {
+    const result = resolveOutputPath(localImage, "png");
+    expect(result).toBe("/home/user/images/photo.png");
+  });
+
+  test("remote image saves in CWD with new extension", () => {
+    const result = resolveOutputPath(remoteImage, "png", { cwd: "/tmp/work" });
+    expect(result).toBe("/tmp/work/photo.png");
+  });
+
+  test("--output override resolves to an absolute path", () => {
+    const result = resolveOutputPath(localImage, "png", { output: "out/converted.png", cwd: "/tmp/work" });
+    expect(result).toBe("/tmp/work/out/converted.png");
+  });
+
+  test("jpeg format uses .jpg extension", () => {
+    const result = resolveOutputPath(localImage, "jpeg");
+    expect(result).toBe("/home/user/images/photo.jpg");
+  });
+
+  test("png and webp formats use their own extension", () => {
+    expect(resolveOutputPath(localImage, "png")).toBe("/home/user/images/photo.png");
+    expect(resolveOutputPath(localImage, "webp")).toBe("/home/user/images/photo.webp");
+  });
+});


### PR DESCRIPTION
## Summary

- Extracts the output path derivation logic from `index.ts` into a pure, unit-testable `resolveOutputPath()` function in `src/output-path.ts`
- Covers all three rules: local → save next to source, remote → save in CWD, `--output` override → resolve explicitly
- Internalises the `jpeg → jpg` extension mapping
- Adds 5 unit tests in `test/output-path.test.ts` that run in ~12ms (vs. subprocess spawns previously)
- Fixes pre-existing lint errors in `test/loader.test.ts` (`_url` unused params)

## Test plan

- [x] `bun test` — 52 tests pass, 0 failures
- [x] `bun run lint` — 0 errors
- [x] Verify `convert` subcommand still writes output to correct location for local files, remote URLs, and `--output` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)