### PR TITLE
Add build pipeline and release infrastructure

### DIFF
--- a/.agents/skills/release-version/SKILL.md
+++ b/.agents/skills/release-version/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: release-version
+description: Release a new version of this CLI. Use when the user wants to cut a release, bump the package version, create a matching git tag, and push the branch and tag so GitHub Actions can publish binaries.
+---
+
+# Release Version
+
+This repo uses a tag-driven GitHub Actions release flow. The manual release work is:
+
+1. Update `package.json` version.
+2. Commit that change.
+3. Create a matching git tag such as `v0.2.0`.
+4. Push the branch and the tag.
+
+After the tag is pushed, `.github/workflows/release.yml` builds and publishes the release artifacts.
+
+## Workflow
+
+### 1. Confirm release target
+
+Identify the target version from the user request. Use:
+
+- package version format: `0.2.0`
+- git tag format: `v0.2.0`
+
+If the user gives only the tag, derive the package version by removing the leading `v`.
+
+### 2. Check repo state
+
+Before editing anything:
+
+- run `git status --short`
+- do not overwrite unrelated user changes
+- if the worktree is dirty in a way that conflicts with the release bump, stop and ask
+
+### 3. Update version
+
+Edit only `package.json` for the version bump. In this repo, `package.json` is the single source of truth for the CLI version.
+
+Do not manually edit the CLI version in `src/index.ts` unless the repo changes its versioning approach later.
+
+### 4. Verify before tagging
+
+Unless the user explicitly asks to skip checks, run:
+
+```bash
+bun run build
+bun run test:binary
+bun run lint
+```
+
+If a check fails, do not create the tag until the user decides how to proceed.
+
+### 5. Commit the release
+
+Use a direct non-interactive commit command. Preferred message:
+
+```bash
+git commit -m "Release v0.2.0"
+```
+
+Replace the version to match the actual release.
+
+### 6. Create the matching tag
+
+Tag must match `package.json` version with a leading `v`:
+
+```bash
+git tag v0.2.0
+```
+
+### 7. Push branch and tag
+
+Push the branch first, then the tag:
+
+```bash
+git push origin main
+git push origin v0.2.0
+```
+
+If the current branch is not `main`, push the current branch name instead of assuming `main`.
+
+### 8. Close the loop
+
+Tell the user that GitHub Actions should now take over and publish the binaries from the tag-triggered release workflow.
+
+## Output Expectations
+
+When using this skill:
+
+- state the target version clearly
+- ensure `package.json` and the tag match exactly
+- use non-interactive git commands only
+- mention when checks were run and whether they passed
+- mention that release publishing happens after tag push, not before
+
+## Reference
+
+If you need the full repository runbook, read `docs/releasing.md`.

--- a/.claude/skills/release-version/SKILL.md
+++ b/.claude/skills/release-version/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: release-version
+description: Release a new version of this CLI. Use when the user wants to cut a release, bump the package version, create a matching git tag, and push the branch and tag so GitHub Actions can publish binaries.
+---
+
+# Release Version
+
+This repo uses a tag-driven GitHub Actions release flow. The manual release work is:
+
+1. Update `package.json` version.
+2. Commit that change.
+3. Create a matching git tag such as `v0.2.0`.
+4. Push the branch and the tag.
+
+After the tag is pushed, `.github/workflows/release.yml` builds and publishes the release artifacts.
+
+## Workflow
+
+### 1. Confirm release target
+
+Identify the target version from the user request. Use:
+
+- package version format: `0.2.0`
+- git tag format: `v0.2.0`
+
+If the user gives only the tag, derive the package version by removing the leading `v`.
+
+### 2. Check repo state
+
+Before editing anything:
+
+- run `git status --short`
+- do not overwrite unrelated user changes
+- if the worktree is dirty in a way that conflicts with the release bump, stop and ask
+
+### 3. Update version
+
+Edit only `package.json` for the version bump. In this repo, `package.json` is the single source of truth for the CLI version.
+
+Do not manually edit the CLI version in `src/index.ts` unless the repo changes its versioning approach later.
+
+### 4. Verify before tagging
+
+Unless the user explicitly asks to skip checks, run:
+
+```bash
+bun run build
+bun run test:binary
+bun run lint
+```
+
+If a check fails, do not create the tag until the user decides how to proceed.
+
+### 5. Commit the release
+
+Use a direct non-interactive commit command. Preferred message:
+
+```bash
+git commit -m "Release v0.2.0"
+```
+
+Replace the version to match the actual release.
+
+### 6. Create the matching tag
+
+Tag must match `package.json` version with a leading `v`:
+
+```bash
+git tag v0.2.0
+```
+
+### 7. Push branch and tag
+
+Push the branch first, then the tag:
+
+```bash
+git push origin main
+git push origin v0.2.0
+```
+
+If the current branch is not `main`, push the current branch name instead of assuming `main`.
+
+### 8. Close the loop
+
+Tell the user that GitHub Actions should now take over and publish the binaries from the tag-triggered release workflow.
+
+## Output Expectations
+
+When using this skill:
+
+- state the target version clearly
+- ensure `package.json` and the tag match exactly
+- use non-interactive git commands only
+- mention when checks were run and whether they passed
+- mention that release publishing happens after tag push, not before
+
+## Reference
+
+If you need the full repository runbook, read `docs/releasing.md`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: bun-darwin-arm64
+            asset_suffix: macos-arm64
+            executable_name: upload-cli
+          - target: bun-darwin-x64
+            asset_suffix: macos-x64
+            executable_name: upload-cli
+          - target: bun-linux-arm64
+            asset_suffix: linux-arm64
+            executable_name: upload-cli
+          - target: bun-linux-x64
+            asset_suffix: linux-x64
+            executable_name: upload-cli
+          - target: bun-windows-x64
+            asset_suffix: windows-x64
+            executable_name: upload-cli.exe
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.11"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build standalone binary
+        run: |
+          mkdir -p dist/release
+          bun build --compile src/index.ts \
+            --outfile "dist/release/${{ matrix.executable_name }}" \
+            --target "${{ matrix.target }}"
+
+      - name: Smoke test native Linux binary
+        if: matrix.target == 'bun-linux-x64'
+        run: ./dist/release/upload-cli --help
+
+      - name: Package archive
+        env:
+          ASSET_BASENAME: upload-cli-${{ github.ref_name }}-${{ matrix.asset_suffix }}
+        run: |
+          cd dist/release
+          zip -j "../${ASSET_BASENAME}.zip" "${{ matrix.executable_name }}"
+          cd ..
+          sha256sum "${ASSET_BASENAME}.zip" > "${ASSET_BASENAME}.sha256"
+
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            dist/upload-cli-${{ github.ref_name }}-${{ matrix.asset_suffix }}.zip
+            dist/upload-cli-${{ github.ref_name }}-${{ matrix.asset_suffix }}.sha256

--- a/README.md
+++ b/README.md
@@ -1,14 +1,38 @@
 # upload-cli
 
-Local setup
+CLI for image format conversion and resizing.
 
-1. Install dependencies (if you haven't already):
-bun install
-2. Link the CLI globally:
-bun link
+## Install
 
-2. This registers upload-cli as a global command using the bin entry in package.json.
-3. Try it out:
+Preferred distribution is a standalone binary from GitHub Releases. These binaries are built with `bun build --compile`, so end users do not need Bun installed.
+
+### macOS and Linux
+
+1. Download the matching release asset for your platform:
+   - `upload-cli-vX.Y.Z-macos-arm64.zip`
+   - `upload-cli-vX.Y.Z-macos-x64.zip`
+   - `upload-cli-vX.Y.Z-linux-arm64.zip`
+   - `upload-cli-vX.Y.Z-linux-x64.zip`
+2. Unzip it.
+3. Move `upload-cli` somewhere on your `PATH`, for example `/usr/local/bin`.
+
+Example:
+
+```bash
+unzip upload-cli-v0.1.0-macos-arm64.zip
+chmod +x upload-cli
+mv upload-cli /usr/local/bin/upload-cli
+```
+
+### Windows
+
+1. Download `upload-cli-vX.Y.Z-windows-x64.zip`.
+2. Extract `upload-cli.exe`.
+3. Put it in a directory on your `PATH`.
+
+## Usage
+
+```bash
 # Convert format
 upload-cli convert photo.png --to webp
 
@@ -22,10 +46,53 @@ upload-cli convert photo.png --to jpeg --height 600
 upload-cli convert photo.png --to webp --width 800 --height 600 --fit contain
 upload-cli convert photo.png --to webp --width 800 --height 600 --fit cover
 upload-cli convert photo.png --to webp --width 800 --height 600 --fit fill
+```
 
-3. Or without linking, run directly:
+## Local Development
+
+Install dependencies:
+
+```bash
+bun install
+```
+
+Link the CLI globally:
+
+```bash
+bun link
+```
+
+Run without linking:
+
+```bash
 bun src/index.ts convert photo.png --to webp --width 800
+```
 
-Unlink
+Unlink:
 
-`bun unlink`
+```bash
+bun unlink
+```
+
+Build a local standalone binary:
+
+```bash
+bun run build
+```
+
+## Release Process
+
+Push a version tag such as `v0.2.0`:
+
+```bash
+git tag v0.2.0
+git push origin v0.2.0
+```
+
+GitHub Actions will build and attach release archives for:
+
+- macOS arm64
+- macOS x64
+- Linux arm64
+- Linux x64
+- Windows x64

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,138 @@
+# Releasing
+
+This project is released as standalone binaries built with Bun. End users install the binary from GitHub Releases and do not need Bun installed.
+
+## Release Checklist
+
+1. Make sure your working tree is clean.
+
+```bash
+git status --short
+```
+
+2. Update the version in `package.json`.
+
+Example:
+
+```json
+{
+  "version": "0.2.0"
+}
+```
+
+Notes:
+
+- `package.json` is the single source of truth for the CLI version.
+- `upload-cli --version` reads from `package.json`.
+- The Git tag must match the package version, with a leading `v`.
+
+3. Run the release verification commands locally.
+
+```bash
+bun install
+bun run build
+bun run test:binary
+bun run lint
+```
+
+4. Commit the version bump and any release notes or docs updates.
+
+Example:
+
+```bash
+git add package.json README.md docs/releasing.md .github/workflows/release.yml
+git commit -m "Release v0.2.0"
+```
+
+Adjust the file list to match your actual changes.
+
+5. Push the commit to the main branch.
+
+```bash
+git push origin main
+```
+
+6. Create a version tag that matches `package.json`.
+
+If `package.json` says `0.2.0`, the tag must be `v0.2.0`.
+
+```bash
+git tag v0.2.0
+```
+
+7. Push the tag.
+
+```bash
+git push origin v0.2.0
+```
+
+8. Wait for the GitHub Actions release workflow to finish.
+
+The workflow is defined in `.github/workflows/release.yml`. It runs when a tag matching `v*` is pushed.
+
+9. Verify the GitHub Release contains all expected assets.
+
+Expected archives:
+
+- `upload-cli-v0.2.0-macos-arm64.zip`
+- `upload-cli-v0.2.0-macos-x64.zip`
+- `upload-cli-v0.2.0-linux-arm64.zip`
+- `upload-cli-v0.2.0-linux-x64.zip`
+- `upload-cli-v0.2.0-windows-x64.zip`
+
+Expected checksum files:
+
+- `upload-cli-v0.2.0-macos-arm64.sha256`
+- `upload-cli-v0.2.0-macos-x64.sha256`
+- `upload-cli-v0.2.0-linux-arm64.sha256`
+- `upload-cli-v0.2.0-linux-x64.sha256`
+- `upload-cli-v0.2.0-windows-x64.sha256`
+
+10. Smoke test one downloaded artifact from the release page.
+
+Example on macOS or Linux:
+
+```bash
+unzip upload-cli-v0.2.0-macos-arm64.zip
+chmod +x upload-cli
+./upload-cli --version
+./upload-cli --help
+```
+
+## What the Release Workflow Does
+
+When you push a tag like `v0.2.0`, GitHub Actions:
+
+1. Installs Bun and project dependencies.
+2. Builds standalone executables with `bun build --compile`.
+3. Produces binaries for:
+   - macOS arm64
+   - macOS x64
+   - Linux arm64
+   - Linux x64
+   - Windows x64
+4. Packages each binary into a zip archive.
+5. Generates a `.sha256` checksum for each archive.
+6. Uploads those files to the GitHub Release for that tag.
+
+## Release Commands
+
+For a `0.2.0` release:
+
+```bash
+bun run build
+bun run test:binary
+bun run lint
+git add package.json
+git commit -m "Release v0.2.0"
+git push origin main
+git tag v0.2.0
+git push origin v0.2.0
+```
+
+## Common Mistakes
+
+- Updating the tag but not `package.json`
+- Updating `package.json` but pushing a mismatched tag
+- Forgetting to push the tag after creating it locally
+- Assuming users install with Bun instead of downloading the compiled release asset

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   ],
   "scripts": {
     "lint": "eslint .",
-    "compile": "bun build --compile src/index.ts --outfile dist/upload-cli"
+    "build": "bun build --compile src/index.ts --outfile dist/upload-cli",
+    "compile": "bun run build",
+    "test:binary": "bun test test/binary.test.ts"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { loadImage } from "./loader";
 import { resolveOutputPath } from "./output-path";
 import { parseFormat, FORMATS } from "./formats";
 import { initWebP } from "./jimp";
+import packageJson from "../package.json";
 
 function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes}B`;
@@ -145,7 +146,7 @@ const convertCommand = defineCommand({
 const main = defineCommand({
   meta: {
     name: "upload-cli",
-    version: "0.1.0",
+    version: packageJson.version,
     description: "Fast CLI tool for image format conversion",
   },
   subCommands: {

--- a/test/binary.test.ts
+++ b/test/binary.test.ts
@@ -1,6 +1,7 @@
 import { test, expect, describe, beforeAll, afterEach } from "bun:test";
 import fs from "fs/promises";
 import path from "path";
+import packageJson from "../package.json";
 
 const BINARY = path.resolve("dist/upload-cli");
 const FIXTURES = path.resolve("test/fixtures");
@@ -51,6 +52,13 @@ beforeAll(async () => {
 });
 
 describe("standalone binary: help", () => {
+  test("--version exits 0 and prints package version", async () => {
+    const { exitCode, stdout } = await run("--version");
+
+    expect(exitCode).toBe(0);
+    expect(stdout.trim()).toBe(packageJson.version);
+  });
+
   test("--help exits 0 and prints usage", async () => {
     const { exitCode, stdout } = await run("--help");
 


### PR DESCRIPTION
## Summary

- Dynamic version: `src/index.ts` now reads the version from `package.json` so `--version` is always in sync
- Build script: `compile` renamed to `build` (alias kept); `test:binary` script added
- GitHub Actions workflow (`.github/workflows/release.yml`): builds standalone binaries for 5 platforms (macOS arm64/x64, Linux arm64/x64, Windows x64) on any `v*` tag push
- Release docs: `docs/releasing.md` step-by-step checklist, README rewritten with binary install instructions for all platforms

## Test plan

- [ ] `bun run build` produces `dist/upload-cli`
- [ ] `bun run test:binary` passes, including the new `--version` smoke test
- [ ] Push a `v*` tag and verify GitHub Actions creates a release with all 5 platform archives + `.sha256` checksums
- [ ] `./upload-cli --version` prints the version from `package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)